### PR TITLE
fix: migrate resizable components to react-resizable-panels v4 API

### DIFF
--- a/app/components/ui/resizable.tsx
+++ b/app/components/ui/resizable.tsx
@@ -6,8 +6,8 @@ import { cn } from "~/lib/utils";
 const ResizablePanelGroup = ({
 	className,
 	...props
-}: React.ComponentProps<typeof ResizablePrimitive.PanelGroup>) => (
-	<ResizablePrimitive.PanelGroup
+}: React.ComponentProps<typeof ResizablePrimitive.Group>) => (
+	<ResizablePrimitive.Group
 		className={cn(
 			"flex h-full w-full data-[panel-group-direction=vertical]:flex-col",
 			className,
@@ -22,10 +22,10 @@ const ResizableHandle = ({
 	withHandle,
 	className,
 	...props
-}: React.ComponentProps<typeof ResizablePrimitive.PanelResizeHandle> & {
+}: React.ComponentProps<typeof ResizablePrimitive.Separator> & {
 	withHandle?: boolean;
 }) => (
-	<ResizablePrimitive.PanelResizeHandle
+	<ResizablePrimitive.Separator
 		className={cn(
 			"relative flex w-px items-center justify-center bg-border after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 data-[panel-group-direction=vertical]:h-px data-[panel-group-direction=vertical]:w-full data-[panel-group-direction=vertical]:after:left-0 data-[panel-group-direction=vertical]:after:h-1 data-[panel-group-direction=vertical]:after:w-full data-[panel-group-direction=vertical]:after:-translate-y-1/2 data-[panel-group-direction=vertical]:after:translate-x-0 [&[data-panel-group-direction=vertical]>div]:rotate-90",
 			className,
@@ -37,7 +37,7 @@ const ResizableHandle = ({
 				<GripVertical className="h-2.5 w-2.5" />
 			</div>
 		)}
-	</ResizablePrimitive.PanelResizeHandle>
+	</ResizablePrimitive.Separator>
 );
 
 export { ResizablePanelGroup, ResizablePanel, ResizableHandle };

--- a/app/routes/new.tsx
+++ b/app/routes/new.tsx
@@ -206,8 +206,8 @@ export default function Index() {
 	return (
 		<DefaultLayout>
 			<div className="container mx-auto py-3 h-full">
-				<ResizablePanelGroup direction="horizontal" className="h-full">
-					<ResizablePanel className="p-3" defaultSize={30}>
+				<ResizablePanelGroup orientation="horizontal" className="h-full">
+					<ResizablePanel className="p-3" defaultSize="30">
 						<Tabs defaultValue="isbn" className="h-full">
 							<TabsList className="grid w-full grid-cols-2">
 								<TabsTrigger value="isbn">ISBN</TabsTrigger>
@@ -258,7 +258,7 @@ export default function Index() {
 					</ResizablePanel>
 					<ResizableHandle />
 
-					<ResizablePanel className="p-3" defaultSize={70}>
+					<ResizablePanel className="p-3" defaultSize="70">
 						<div className="overflow-y-auto h-full">
 							<Table>
 								<TableHeader>

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
 				"lucide-react": "^0.563.0",
 				"react": "^19.0.0",
 				"react-dom": "^19.0.0",
-				"react-resizable-panels": "^3.0.6",
+				"react-resizable-panels": "^4.0.0",
 				"react-router": "^7.0.0",
 				"tailwind-merge": "^3.3.1",
 				"tailwindcss": "^4.1.14",
@@ -10593,13 +10593,13 @@
 			}
 		},
 		"node_modules/react-resizable-panels": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/react-resizable-panels/-/react-resizable-panels-3.0.6.tgz",
-			"integrity": "sha512-b3qKHQ3MLqOgSS+FRYKapNkJZf5EQzuf6+RLiq1/IlTHw99YrZ2NJZLk4hQIzTnnIkRg2LUqyVinu6YWWpUYew==",
+			"version": "4.11.2",
+			"resolved": "https://registry.npmjs.org/react-resizable-panels/-/react-resizable-panels-4.11.2.tgz",
+			"integrity": "sha512-+kfFbDZ8mygc7g0vxOcDzCVGuwiIUOnILqPoUHo6/uP+Mmyx6HzZU+kj1aOPDlktXuobYbr6BtQekvJwHRX4Eg==",
 			"license": "MIT",
 			"peerDependencies": {
-				"react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc",
-				"react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+				"react": "^18.0.0 || ^19.0.0",
+				"react-dom": "^18.0.0 || ^19.0.0"
 			}
 		},
 		"node_modules/react-router": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
 		"lucide-react": "^0.563.0",
 		"react": "^19.0.0",
 		"react-dom": "^19.0.0",
-		"react-resizable-panels": "^3.0.6",
+		"react-resizable-panels": "^4.0.0",
 		"react-router": "^7.0.0",
 		"tailwind-merge": "^3.3.1",
 		"tailwindcss": "^4.1.14",


### PR DESCRIPTION
## 概要

[#226](https://github.com/YuseiIto/bibliophilia/pull/226) の `build_and_lint` CI が `typecheck` ステップで失敗していたため、その修正を行います。本 PR は #226 のブランチ (`renovate/react-resizable-panels-4.x`) を base にしています。

## 失敗の原因

`react-resizable-panels` v3 → v4 はメジャーアップデートで、API に破壊的変更が入っています。`tsc` が以下のエラーで失敗していました:

```
app/components/ui/resizable.tsx(9,51): error TS2339: Property 'PanelGroup' does not exist ...
app/components/ui/resizable.tsx(25,51): error TS2339: Property 'PanelResizeHandle' does not exist ...
```

## 変更内容

v4 の API に合わせて移行しました:

- **`PanelGroup` → `Group`**、**`PanelResizeHandle` → `Separator`** にリネーム（`Panel` は変更なし） — `app/components/ui/resizable.tsx`
- **`direction` prop → `orientation`** — `app/routes/new.tsx`
- **Panel サイズの単位変更**: v4 では数値は「ピクセル」として解釈されるようになったため、これまでの 30% / 70% の比率を維持するためにパーセンテージ文字列 (`"30"` / `"70"`) に変更 — `app/routes/new.tsx`

## 確認

ローカルで CI と同じ手順を実行し、すべて成功することを確認済みです:

- ✅ `npm run build`
- ✅ `npm run lint`
- ✅ `npm test` (58 passed)
- ✅ `npm run typecheck`

https://claude.ai/code/session_015uSUwWtSPXn8QaE7i7qNus

---
_Generated by [Claude Code](https://claude.ai/code/session_015uSUwWtSPXn8QaE7i7qNus)_