### PR TITLE
fix(use-mobile): use useSyncExternalStore to satisfy react-hooks lint

### DIFF
--- a/app/hooks/use-mobile.tsx
+++ b/app/hooks/use-mobile.tsx
@@ -2,20 +2,20 @@ import * as React from "react";
 
 const MOBILE_BREAKPOINT = 768;
 
+function subscribe(callback: () => void) {
+	const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
+	mql.addEventListener("change", callback);
+	return () => mql.removeEventListener("change", callback);
+}
+
+function getSnapshot() {
+	return window.innerWidth < MOBILE_BREAKPOINT;
+}
+
+function getServerSnapshot() {
+	return false;
+}
+
 export function useIsMobile() {
-	const [isMobile, setIsMobile] = React.useState<boolean | undefined>(
-		undefined,
-	);
-
-	React.useEffect(() => {
-		const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
-		const onChange = () => {
-			setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
-		};
-		mql.addEventListener("change", onChange);
-		setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
-		return () => mql.removeEventListener("change", onChange);
-	}, []);
-
-	return !!isMobile;
+	return React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 }


### PR DESCRIPTION
## 概要

PR #290 の CI 失敗（`build_and_lint` ジョブ）を修正します。

## 原因

`eslint-plugin-react-hooks` の `7.0.1 → 7.1.1` 更新により `set-state-in-effect` ルールの検出が強化され、`app/hooks/use-mobile.tsx` で `useEffect` 内の同期的な `setState` 呼び出しが lint エラーになっていました。

```
error  Calling setState synchronously within an effect can trigger cascading renders
```

## 修正

`useIsMobile` を `useSyncExternalStore` を使う実装に書き換えました。matchMedia という外部ストアを購読する正攻法で、ルール違反を解消しつつ挙動（SSR では `false`）も維持しています。

## 確認

ローカルで以下がすべて成功することを確認済みです。

- `npm run build`
- `npm run lint`
- `npm test`
- `npm run typecheck`

https://claude.ai/code/session_01RXTh3NB3D1TffMzXLUzbV5

---
_Generated by [Claude Code](https://claude.ai/code/session_01RXTh3NB3D1TffMzXLUzbV5)_